### PR TITLE
Force awscli version to 1.12.2 until a better fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
     install_requires=[
         'boto',
         'retrying',
-        'awscli',
+        'awscli==1.12.2',
     ],
 )


### PR DESCRIPTION
12.13.0 fails:

    # awsudo -u profile_name env
    Traceback (most recent call last):
      File "/root/.local/bin/awsudo", line 9, in <module>
	load_entry_point('awsudo==0.0.0', 'console_scripts', 'awsudo')()
      File "/root/.local/lib/python2.7/site-packages/awsudo/main.py", line 68, in main
	run(args, resolver.getEnvironment(profile))
      File "/root/.local/lib/python2.7/site-packages/awsudo/config.py", line 16, in getEnvironment
	session.emit('session-initialized', session=session)
      File "/usr/lib/python2.7/site-packages/botocore/session.py", line 719, in emit
	return self._events.emit(event_name, **kwargs)
      File "/usr/lib/python2.7/site-packages/botocore/hooks.py", line 227, in emit
	return self._emit(event_name, kwargs)
      File "/usr/lib/python2.7/site-packages/botocore/hooks.py", line 210, in _emit
	response = handler(**kwargs)
    TypeError: attach_history_handler() takes exactly 2 arguments (1 given)

See https://github.com/makethunder/awsudo/issues/7

@ktilcu sup