### PR TITLE
register session-initialized event to inject_assume_role_provider_cache to prevent runtime error on awscli 1.12.2+

### DIFF
--- a/awsudo/config.py
+++ b/awsudo/config.py
@@ -1,4 +1,6 @@
 from argparse import Namespace
+
+from awscli.customizations.assumerole import inject_assume_role_provider_cache
 from awscli.handlers import awscli_initialize
 from botocore.session import Session
 from botocore.hooks import HierarchicalEmitter
@@ -13,12 +15,11 @@ class CredentialResolver(object):
         if profile:
             session.set_config_variable('profile', profile)
 
-        awscli_initialize(eventHooks)
+        eventHooks.register('session-initialized',
+                            inject_assume_role_provider_cache,
+                            unique_id='inject_assume_role_cred_provider_cache')
 
-        parsed_args = Namespace()
-        parsed_args.command = None
-
-        session.emit('session-initialized', session=session, parsed_args=parsed_args)
+        session.emit('session-initialized', session=session)
         creds = session.get_credentials()
 
         env = {}

--- a/awsudo/config.py
+++ b/awsudo/config.py
@@ -1,7 +1,4 @@
-from argparse import Namespace
-
 from awscli.customizations.assumerole import inject_assume_role_provider_cache
-from awscli.handlers import awscli_initialize
 from botocore.session import Session
 from botocore.hooks import HierarchicalEmitter
 

--- a/awsudo/config.py
+++ b/awsudo/config.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from awscli.handlers import awscli_initialize
 from botocore.session import Session
 from botocore.hooks import HierarchicalEmitter
@@ -13,7 +14,11 @@ class CredentialResolver(object):
             session.set_config_variable('profile', profile)
 
         awscli_initialize(eventHooks)
-        session.emit('session-initialized', session=session)
+
+        parsed_args = Namespace()
+        parsed_args.command = None
+
+        session.emit('session-initialized', session=session, parsed_args=parsed_args)
         creds = session.get_credentials()
 
         env = {}

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
     install_requires=[
         'boto',
         'retrying',
-        'awscli==1.12.2',
+        'awscli',
     ],
 )


### PR DESCRIPTION
I'm looking into the root cause of runtime failure and try to fix it. if we look into this PR https://github.com/aws/aws-cli/pull/2993, it's caused by addition of new feature in newer version of awscli, history command which relies on https://github.com/boto/botocore/pull/1315

session-initialized event are registered to attach_handler_history

from awscli_initialize in awscli.handlers
```
register_history_mode(event_handlers)
```

from init in awscli.customizations.history
```
def register_history_mode(event_handlers):
    event_handlers.register(
        'session-initialized', attach_history_handler)
```

because of that, we need to register 'session-initialized' event to inject_assume_role_provider_cache. this method will get credential from cache. If I looked into the code we  probably able to take out awscli from awsudo entirely and fetch the cache credentials using separate method instead of make awscli as dependency. Because, we only need the credentials not initializing to entire services, CMIIW

here is inject cache cred 
```
def inject_assume_role_provider_cache(session, **kwargs):
    try:
        cred_chain = session.get_component('credential_provider')
    except ProfileNotFound:
        LOG.debug("ProfileNotFound caught when trying to inject "
                  "assume-role cred provider cache.  Not configuring "
                  "JSONFileCache for assume-role.")
        return
    provider = cred_chain.get_provider('assume-role')
    provider.cache = JSONFileCache(CACHE_DIR)
```