### PR TITLE
USE of AWS_PROFILE

### DIFF
--- a/awsudo/config.py
+++ b/awsudo/config.py
@@ -25,6 +25,9 @@ class CredentialResolver(object):
             if value:
                 env[key] = value
 
+        if profile:
+            set('AWS_PROFILE', profile)
+
         set('AWS_ACCESS_KEY_ID', creds.access_key)
         set('AWS_SECRET_ACCESS_KEY', creds.secret_key)
 

--- a/awsudo/main.py
+++ b/awsudo/main.py
@@ -49,7 +49,7 @@ def parseArgs():
     if not (args):
         usage()
 
-    profile = None
+    profile = os.environ.get('AWS_PROFILE')
     for (option, value) in options:
         if option == '-u':
             profile = value

--- a/awsudo/test/test_main.py
+++ b/awsudo/test/test_main.py
@@ -16,6 +16,45 @@ def test_no_args(capsys, monkeypatch):
     assert 'Usage:' in err
 
 
+def test_only_option(capsys, monkeypatch):
+    '''With only options, awsudo exits with usage.'''
+    monkeypatch.setattr(sys, 'argv', ['awsudo', '-u', 'default'])
+
+    with pytest.raises(SystemExit):
+        main.main()
+
+    out, err = capsys.readouterr()
+    assert 'Usage:' in err
+
+
+def test_parseArgs_env_profile(monkeypatch):
+    '''Env vars is taken if no option are given.'''
+    environ = {
+        'AWS_PROFILE': 'profile'
+    }
+    monkeypatch.setattr(os, 'environ', environ)
+    monkeypatch.setattr(sys, 'argv', ['awsudo', 'command'])
+
+    profile, args = main.parseArgs()
+
+    assert profile == 'profile'
+    assert args == ['command']
+
+
+def test_parseArgs_option_over_environ(monkeypatch):
+    '''Options values are taken even if environment variables are set.'''
+    environ = {
+        'AWS_PROFILE': 'profile-environ'
+    }
+    monkeypatch.setattr(os, 'environ', environ)
+    monkeypatch.setattr(sys, 'argv', ['awsudo', '-u', 'profile-option', 'command'])
+
+    profile, args = main.parseArgs()
+
+    assert profile == 'profile-option'
+    assert args == ['command']
+
+
 def test_cleanEnvironment(monkeypatch):
     '''cleanEnvironment strips AWS and boto configuration.'''
     environ = {


### PR DESCRIPTION
Two behaviours adapted:
* If AWS_PROFILE is set, it will be used as default value for the user/profile. Of course if the option `-u` is specified, its value is taken.
* If a user/profile is given, be it by environment variable or argument, `awsudo` will use its value to set a new aws variable: `AWS_PROFILE`. 
